### PR TITLE
feat(settings): auto-enable master password

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,8 +39,7 @@
           </div>
         </fieldset>
         <fieldset><legend>全局</legend>
-          <label>主密码 (解锁用) <input name="masterPassword" id="masterPassword" data-field="masterPassword" type="password" placeholder="未勾选下方“主密码加密”则不会使用" autocomplete="new-password"/></label>
-          <label>主密码加密 <input type="checkbox" name="useMasterPassword" data-field="useMasterPassword"/></label>
+          <label>主密码 (解锁用) <input name="masterPassword" id="masterPassword" data-field="masterPassword" type="password" placeholder="留空则不启用" autocomplete="new-password"/></label>
           <label>默认目标语言 <select name="targetLanguage" data-field="targetLanguage"></select></label>
           <label>Prompt 模板</label>
           <textarea name="promptTemplate" data-field="promptTemplate" rows="10" placeholder="Prompt 模板"></textarea>

--- a/js/config.js
+++ b/js/config.js
@@ -174,6 +174,7 @@ export function loadConfig(){
     if (!data.promptTemplate || data.promptTemplate === '加载中...') data.promptTemplate = DEFAULT_PROMPT_TEMPLATE;
     // 规范化全局数字字段
     ['temperature','maxTokens','timeoutMs','retries'].forEach(k=>{ if (data[k]!==undefined && data[k]!=='' ) data[k] = Number(data[k]); });
+    data.useMasterPassword = !!data.masterPasswordEnc;
     // 规范化服务级温度/最大 Token（若未触发 normalizeServices）
     if (Array.isArray(data.services)){
       data.services = data.services.map(s=>({

--- a/settings.html
+++ b/settings.html
@@ -15,7 +15,6 @@
       <label>Max Tokens <input type="number" min="1" name="maxTokens" data-field="maxTokens"/></label>
       <label>超时(ms) <input type="number" min="1000" name="timeoutMs" data-field="timeoutMs" placeholder="30000"/></label>
   <label>重试次数 <input type="number" min="0" max="5" name="retries" data-field="retries" placeholder="2"/></label>
-      <label>主密码加密 <input type="checkbox" name="useMasterPassword" data-field="useMasterPassword"/></label>
       <label>Store Responses <input type="checkbox" name="storeResponses" data-field="storeResponses"/></label>
     </fieldset>
     <fieldset><legend>Prompt 模板</legend>


### PR DESCRIPTION
## Summary
- show a masked placeholder once a master password is saved
- auto-enable master password encryption and drop manual toggle
- keep config `useMasterPassword` in sync with encrypted value

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b9baed4d24832c9aad5a966ccfa9c4