### PR TITLE
feat: add basic PWA support

### DIFF
--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -1,6 +1,6 @@
 {
-  "name": "AI Transtor",
-  "short_name": "Transtor",
+  "name": "AI Translator",
+  "short_name": "Translator",
   "start_url": ".",
   "display": "standalone",
   "background_color": "#ffffff",

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'ai-transtor-cache-v1';
+const CACHE_NAME = 'ai-translator-cache-v1';
 const CORE_ASSETS = [
   './index.html',
   './css/base.css',
@@ -15,9 +15,10 @@ self.addEventListener('install', event => {
     await cache.addAll(CORE_ASSETS);
     try {
       const res = await fetch('./js/chunk-manifest.json');
+      const copy = res.clone();
       const files = await res.json();
       await cache.addAll(files);
-      cache.put('./js/chunk-manifest.json', res);
+      await cache.put('./js/chunk-manifest.json', copy);
     } catch (e) {
       // chunk manifest not found – likely dev mode
     }
@@ -39,9 +40,10 @@ self.addEventListener('fetch', event => {
   event.respondWith(
     caches.match(event.request).then(resp => {
       if (resp) return resp;
-      return fetch(event.request).then(r => {
+      return fetch(event.request).then(async r => {
         const copy = r.clone();
-        caches.open(CACHE_NAME).then(cache => cache.put(event.request, copy));
+        const cache = await caches.open(CACHE_NAME);
+        await cache.put(event.request, copy);
         return r;
       });
     }).catch(() => {


### PR DESCRIPTION
## Summary
- add web manifest, service worker and registration script for offline capability
- update build script to bundle and copy PWA assets
- document PWA support in README
- clone chunk manifest response before caching and correct naming

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ba980ce3b8832c85299ff7e761f291