### PR TITLE
fix: decouple cache writes from network response

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -40,10 +40,13 @@ self.addEventListener('fetch', event => {
   event.respondWith(
     caches.match(event.request).then(resp => {
       if (resp) return resp;
-      return fetch(event.request).then(async r => {
+      return fetch(event.request).then(r => {
         const copy = r.clone();
-        const cache = await caches.open(CACHE_NAME);
-        await cache.put(event.request, copy);
+        event.waitUntil(
+          caches.open(CACHE_NAME)
+            .then(cache => cache.put(event.request, copy))
+            .catch(() => {})
+        );
         return r;
       });
     }).catch(() => {


### PR DESCRIPTION
## Summary
- avoid rejecting successful fetches if cache write fails by moving cache update to `event.waitUntil`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ba99f15628832cb62ff842ef5b9fb2