### PR TITLE
fix: handle cache.put failures in network-first fetch

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -41,7 +41,13 @@ self.addEventListener('fetch', event => {
     const cache = await caches.open(CACHE_NAME);
     try {
       const response = await fetch(event.request);
-      event.waitUntil(cache.put(event.request, response.clone()));
+      event.waitUntil((async () => {
+        try {
+          await cache.put(event.request, response.clone());
+        } catch (e) {
+          // ignore caching errors
+        }
+      })());
       return response;
     } catch {
       const cached = await cache.match(event.request);


### PR DESCRIPTION
## Summary
- swallow caching errors so service worker fetches succeed even if cache writes fail

## Testing
- ✅ `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ba9d7e8d30832cafc317689d2bfb2b