### PR TITLE
fix: precache default prompt

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -6,6 +6,7 @@ const CORE_ASSETS = [
   './js/ui-settings-modal.js',
   './js/pwa.js',
   './manifest.webmanifest',
+  './default.prompt',
   './favicon.ico'
 ];
 


### PR DESCRIPTION
## Summary
- add default prompt file to service worker precache list so offline users get seeded template

## Testing
- ⚠️ `npm test` (missing script: "test")
- ✅ `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ba9fd7eaa4832c97edca21916d9334