### PR TITLE
feat: support dragging text into input field

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
   </section>
   <section class="panes">
     <div class="pane">
-      <textarea id="inputText" placeholder="在此粘贴待翻译文本或拖拽 .txt 文件" spellcheck="false"></textarea>
+      <textarea id="inputText" placeholder="在此粘贴或拖拽待翻译文本（含 .txt 文件）" spellcheck="false"></textarea>
     </div>
     <div class="pane">
       <textarea id="outputText" readonly placeholder="译文输出 (流式)..."></textarea>

--- a/js/ui-translate.js
+++ b/js/ui-translate.js
@@ -153,16 +153,27 @@ window.addEventListener('keydown', e=>{
   else if (e.key==='Escape'){ if (streaming) cancelStream(); }
 });
 
-// 拖拽 txt 文件
+// 拖拽 txt 文件或文本内容
 inputEl.addEventListener('dragover', e=>{ e.preventDefault(); });
 inputEl.addEventListener('drop', e=>{
   e.preventDefault();
-  const f = e.dataTransfer.files[0]; if (!f) return;
-  if (f.type === 'text/plain' || f.name.endsWith('.txt')){
-    const reader = new FileReader();
-  reader.onload = ()=>{ inputEl.value = reader.result; setStatus('文件已载入'); };
-    reader.readAsText(f);
-  } else setStatus('仅支持 .txt');
+  const dt = e.dataTransfer;
+  const f = dt.files[0];
+  if (f){
+    if (f.type === 'text/plain' || f.name.endsWith('.txt')){
+      const reader = new FileReader();
+      reader.onload = ()=>{ inputEl.value = reader.result; setStatus('文件已载入'); };
+      reader.readAsText(f);
+    } else {
+      setStatus('仅支持 .txt');
+    }
+    return;
+  }
+  const text = dt.getData('text/plain') || dt.getData('text');
+  if (text){
+    inputEl.value = text;
+    setStatus('文本已载入');
+  }
 });
 
 (function init(){


### PR DESCRIPTION
## Summary
- allow dropping plain text into input area in addition to .txt files
- clarify placeholder text about dragging text

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bc9f680528832c8b06b6eb6ae1dc1d