### PR TITLE
feat: add light theme and sidebar settings actions

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -1,5 +1,5 @@
 :root{--bg:#121417;--fg:#e6e8ea;--fg-dim:#9aa0a6;--accent:#3d7bfd;--danger:#d93939;--border:#2a2f36;--surface:#1e242b;--surface-alt:#0f1214;--bar-bg:#0d0f11;--input-bg:#1a1f24;--radius:6px;--gap:12px;--font:system-ui,-apple-system,Segoe UI,Roboto,sans-serif;--mono:ui-monospace,monaco,monospace;}
-:root[data-theme='light']{--bg:#ffffff;--fg:#1a1d21;--fg-dim:#606368;--accent:#0b57d0;--danger:#d93939;--border:#d0d7de;--surface:#f3f4f6;--surface-alt:#ffffff;--bar-bg:#f6f8fa;--input-bg:#ffffff;}
+:root[data-theme='light']{--bg:#f6f8fa;--fg:#1a1d21;--fg-dim:#606368;--accent:#0b57d0;--danger:#d93939;--border:#d0d7de;--surface:#ffffff;--surface-alt:#ffffff;--bar-bg:#f6f8fa;--input-bg:#ffffff;}
 *{box-sizing:border-box}html,body{margin:0;padding:0;height:100%;background:var(--bg);color:var(--fg);font-family:var(--font);-webkit-font-smoothing:antialiased}
 body{display:flex;flex-direction:column;min-height:600px}
 .bar{display:flex;align-items:center;justify-content:space-between;padding:8px 14px;background:var(--bar-bg);left:env(titlebar-area-x,0);top:env(titlebar-area-y,0);height:env(titlebar-area-height,50px);width:env(titlebar-area-width,100%);app-region:drag}
@@ -12,6 +12,15 @@ body{display:flex;flex-direction:column;min-height:600px}
 .btn.primary{background:var(--accent);color:#fff;border:none}
 .btn.danger{background:var(--danger);color:#fff;border:none}
 .btn:disabled{opacity:.5;cursor:not-allowed}
+/* Generic icon button (used by header/theme toggle) */
+.icon-btn{width:30px;height:30px;display:flex;align-items:center;justify-content:center;background:var(--surface);color:var(--fg);border:1px solid var(--border);border-radius:var(--radius);cursor:pointer}
+.icon-btn[aria-pressed="true"]{outline:none}
+.icon-btn:focus{outline:none}
+.icon-btn:focus-visible{outline:2px solid var(--accent); outline-offset:0}
+.icon-btn svg{width:18px;height:18px;display:block}
+.bar .icon-btn{app-region:no-drag;background:var(--bar-bg);border-color:var(--bar-bg)}
+.bar .icon-btn:hover{background:var(--bar-bg);border-color:var(--bar-bg)}
+.bar-tools{display:flex;gap:8px;align-items:center}
 .panes{flex:1;display:grid;grid-template-columns:1fr 1fr;gap:var(--gap);min-height:0}
 .pane{display:flex;flex-direction:column;min-height:0}
 textarea{flex:1;width:100%;resize:vertical;background:var(--surface-alt);color:var(--fg);border:1px solid var(--border);border-radius:var(--radius);padding:10px;font:14px var(--mono);line-height:1.5}
@@ -23,16 +32,30 @@ label{display:flex;flex-direction:column;font-size:12px;gap:4px}
 input,select{background:var(--input-bg);color:var(--fg);border:1px solid var(--border);border-radius:var(--radius);padding:6px;font:13px var(--font)}
 input:focus,select:focus{outline:2px solid var(--accent);outline-offset:0}
 .settings-body{display:flex;gap:16px}
-.settings-actions{display:flex;flex-direction:column;gap:8px;min-width:140px}
+.settings-actions{display:flex;flex-direction:column;gap:8px;min-width:100px}
 .settings-actions .btn{width:100%}
 .settings-actions .btn-row{flex-direction:column}
 .settings-actions .status{margin-top:auto}
+/* Icons + collapse styles for settings actions */
+.settings-actions .btn{display:flex;align-items:center;gap:8px}
+.settings-actions .btn .icon{display:inline-flex;width:16px;height:16px}
+.settings-actions .btn.icon-only{width:auto}
+.settings-actions.collapsed{min-width:46px}
+.settings-actions.collapsed .btn{width:46px;justify-content:center;padding:6px}
+.settings-actions.collapsed .btn .label{display:none}
+.settings-actions.collapsed .btn .icon{margin:0}
+.settings-actions.collapsed .status{display:none}
 .modal-overlay{position:fixed;inset:0;background:rgba(0,0,0,.55);backdrop-filter:saturate(180%) blur(6px);display:flex;align-items:flex-start;justify-content:center;padding:40px 16px;z-index:1000;overflow:auto}
 .modal-overlay[hidden]{display:none !important}
 .modal{background:var(--surface-alt);border:1px solid var(--border);border-radius:12px;padding:0;max-width:760px;width:100%;display:flex;flex-direction:column;box-shadow:0 8px 32px -4px rgba(0,0,0,.6)}
 .modal-bar{display:flex;align-items:center;gap:8px;padding:10px 14px;border-bottom:1px solid var(--border);background:var(--bar-bg)}
 .modal-bar h2{margin:0;font-size:15px;font-weight:600}
 .modal-body{padding:16px;max-height:calc(100vh - 160px);overflow:auto;display:flex;flex-direction:column}
+/* Ensure settings modal uses side-by-side layout */
+.modal-body.settings-body{flex-direction:row;align-items:flex-start}
+.settings-body form{flex:1}
 .flex-gap{flex:1}
-@media (max-width:820px){.modal{max-width:100%;height:100%;border-radius:0}.modal-body{max-height:unset;height:100%;}}
+@media (max-width:820px){.modal{max-width:100%;height:100%;border-radius:0}.modal-body{max-height:unset;height:100%;}.modal-body.settings-body{flex-direction:column}}
 @media (max-width:900px){.panes{grid-template-columns:1fr}.controls{flex-direction:column;align-items:stretch}}
+
+/* Side tools removed: theme toggle moved to header */

--- a/css/base.css
+++ b/css/base.css
@@ -1,32 +1,36 @@
-:root{--bg:#121417;--fg:#e6e8ea;--fg-dim:#9aa0a6;--accent:#3d7bfd;--danger:#d93939;--border:#2a2f36;--radius:6px;--gap:12px;--font:system-ui,-apple-system,Segoe UI,Roboto,sans-serif;--mono:ui-monospace,monaco,monospace;}
+:root{--bg:#121417;--fg:#e6e8ea;--fg-dim:#9aa0a6;--accent:#3d7bfd;--danger:#d93939;--border:#2a2f36;--surface:#1e242b;--surface-alt:#0f1214;--bar-bg:#0d0f11;--input-bg:#1a1f24;--radius:6px;--gap:12px;--font:system-ui,-apple-system,Segoe UI,Roboto,sans-serif;--mono:ui-monospace,monaco,monospace;}
+:root[data-theme='light']{--bg:#ffffff;--fg:#1a1d21;--fg-dim:#606368;--accent:#0b57d0;--danger:#d93939;--border:#d0d7de;--surface:#f3f4f6;--surface-alt:#ffffff;--bar-bg:#f6f8fa;--input-bg:#ffffff;}
 *{box-sizing:border-box}html,body{margin:0;padding:0;height:100%;background:var(--bg);color:var(--fg);font-family:var(--font);-webkit-font-smoothing:antialiased}
 body{display:flex;flex-direction:column;min-height:600px}
-.bar{display: flex;align-items:center;justify-content:space-between;padding:8px 14px;background:#0d0f11; left: env(titlebar-area-x, 0);top: env(titlebar-area-y, 0);height: env(titlebar-area-height, 50px);width: env(titlebar-area-width, 100%); app-region: drag;}
+.bar{display:flex;align-items:center;justify-content:space-between;padding:8px 14px;background:var(--bar-bg);left:env(titlebar-area-x,0);top:env(titlebar-area-y,0);height:env(titlebar-area-height,50px);width:env(titlebar-area-width,100%);app-region:drag}
 .bar a{color:var(--accent);text-decoration:none;font-size:14px}
 .app-title{margin:0;font-size:16px;font-weight:600}
 .layout{width:100%;max-width:1200px;margin:0 auto;padding:var(--gap);flex:1;display:flex;flex-direction:column;gap:var(--gap)}
 .controls{display:flex;flex-wrap:wrap;align-items:flex-end;gap:var(--gap)}
 .btn-row{display:flex;flex-wrap:wrap;gap:var(--gap)}
-.btn{background:#1e242b;color:var(--fg);border:1px solid var(--border);padding:6px 14px;border-radius:var(--radius);cursor:pointer;font:inherit;font-size:14px}
+.btn{background:var(--surface);color:var(--fg);border:1px solid var(--border);padding:6px 14px;border-radius:var(--radius);cursor:pointer;font:inherit;font-size:14px}
 .btn.primary{background:var(--accent);color:#fff;border:none}
 .btn.danger{background:var(--danger);color:#fff;border:none}
 .btn:disabled{opacity:.5;cursor:not-allowed}
 .panes{flex:1;display:grid;grid-template-columns:1fr 1fr;gap:var(--gap);min-height:0}
 .pane{display:flex;flex-direction:column;min-height:0}
-textarea{flex:1;width:100%;resize:vertical;background:#0f1214;color:var(--fg);border:1px solid var(--border);border-radius:var(--radius);padding:10px;font:14px var(--mono);line-height:1.5}
+textarea{flex:1;width:100%;resize:vertical;background:var(--surface-alt);color:var(--fg);border:1px solid var(--border);border-radius:var(--radius);padding:10px;font:14px var(--mono);line-height:1.5}
 textarea:focus{outline:2px solid var(--accent);outline-offset:0}
 .status{margin-top:4px;font-size:12px;color:var(--fg-dim);min-height:16px;word-break:break-all}
 fieldset{border:1px solid var(--border);border-radius:var(--radius);padding:10px;margin-bottom:var(--gap);display:flex;flex-direction:column;gap:8px}
 legend{padding:0 6px;font-size:12px;color:var(--fg-dim)}
 label{display:flex;flex-direction:column;font-size:12px;gap:4px}
-input,select,textarea{background:#1a1f24;color:var(--fg);border:1px solid var(--border);border-radius:var(--radius);padding:6px;font:13px var(--font)}
+input,select{background:var(--input-bg);color:var(--fg);border:1px solid var(--border);border-radius:var(--radius);padding:6px;font:13px var(--font)}
 input:focus,select:focus{outline:2px solid var(--accent);outline-offset:0}
-.settings form{display:flex;flex-direction:column}
-/* Modal */
+.settings-body{display:flex;gap:16px}
+.settings-actions{display:flex;flex-direction:column;gap:8px;min-width:140px}
+.settings-actions .btn{width:100%}
+.settings-actions .btn-row{flex-direction:column}
+.settings-actions .status{margin-top:auto}
 .modal-overlay{position:fixed;inset:0;background:rgba(0,0,0,.55);backdrop-filter:saturate(180%) blur(6px);display:flex;align-items:flex-start;justify-content:center;padding:40px 16px;z-index:1000;overflow:auto}
 .modal-overlay[hidden]{display:none !important}
-.modal{background:#0f1214;border:1px solid var(--border);border-radius:12px;padding:0;max-width:760px;width:100%;display:flex;flex-direction:column;box-shadow:0 8px 32px -4px rgba(0,0,0,.6)}
-.modal-bar{display:flex;align-items:center;gap:8px;padding:10px 14px;border-bottom:1px solid var(--border);background:#0d0f11}
+.modal{background:var(--surface-alt);border:1px solid var(--border);border-radius:12px;padding:0;max-width:760px;width:100%;display:flex;flex-direction:column;box-shadow:0 8px 32px -4px rgba(0,0,0,.6)}
+.modal-bar{display:flex;align-items:center;gap:8px;padding:10px 14px;border-bottom:1px solid var(--border);background:var(--bar-bg)}
 .modal-bar h2{margin:0;font-size:15px;font-weight:600}
 .modal-body{padding:16px;max-height:calc(100vh - 160px);overflow:auto;display:flex;flex-direction:column}
 .flex-gap{flex:1}

--- a/css/base.css
+++ b/css/base.css
@@ -47,8 +47,8 @@ input:focus,select:focus{outline:2px solid var(--accent);outline-offset:0}
 .settings-actions.collapsed .status{display:none}
 .modal-overlay{position:fixed;inset:0;background:rgba(0,0,0,.55);backdrop-filter:saturate(180%) blur(6px);display:flex;align-items:flex-start;justify-content:center;padding:40px 16px;z-index:1000;overflow:auto}
 .modal-overlay[hidden]{display:none !important}
-.modal{background:var(--surface-alt);border:1px solid var(--border);border-radius:12px;padding:0;max-width:760px;width:100%;display:flex;flex-direction:column;box-shadow:0 8px 32px -4px rgba(0,0,0,.6)}
-.modal-bar{display:flex;align-items:center;gap:8px;padding:10px 14px;border-bottom:1px solid var(--border);background:var(--bar-bg)}
+.modal{background:var(--surface-alt);border:1px solid var(--border);border-radius:12px;padding:0;max-width:760px;width:100%;display:flex;flex-direction:column;box-shadow:0 8px 32px -4px rgba(0,0,0,.6);overflow:hidden}
+.modal-bar{display:flex;align-items:center;gap:8px;padding:10px 14px;border-bottom:1px solid var(--border);background:var(--bar-bg);border-top-left-radius:inherit;border-top-right-radius:inherit}
 .modal-bar h2{margin:0;font-size:15px;font-weight:600}
 .modal-body{padding:16px;max-height:calc(100vh - 160px);overflow:auto;display:flex;flex-direction:column}
 /* Ensure settings modal uses side-by-side layout */
@@ -59,3 +59,11 @@ input:focus,select:focus{outline:2px solid var(--accent);outline-offset:0}
 @media (max-width:900px){.panes{grid-template-columns:1fr}.controls{flex-direction:column;align-items:stretch}}
 
 /* Side tools removed: theme toggle moved to header */
+
+/* Position tweaks: only for URL 导入 & 主密码模态，置于视口上 1/3 附近 */
+#importUrlOverlay, #mpPromptOverlay{ align-items:center; padding:16px; }
+#importUrlOverlay .modal, #mpPromptOverlay .modal{ transform:translateY(-16.7vh); }
+@media (max-width:820px){
+  #importUrlOverlay, #mpPromptOverlay{ align-items:flex-start; padding:40px 16px; }
+  #importUrlOverlay .modal, #mpPromptOverlay .modal{ transform:none; }
+}

--- a/index.html
+++ b/index.html
@@ -114,6 +114,49 @@
   </div>
 
   
+  <!-- 导入 URL 模态 -->
+  <div id="importUrlOverlay" class="modal-overlay" hidden>
+    <div class="modal" role="dialog" aria-modal="true" aria-labelledby="importUrlTitle">
+      <header class="modal-bar">
+        <h2 id="importUrlTitle">URL 导入</h2>
+        <div class="flex-gap"></div>
+        <button id="closeImportUrl" class="btn">关闭 (Esc)</button>
+      </header>
+      <div class="modal-body">
+        <form id="importUrlForm">
+          <label>配置 URL
+            <input id="importUrlInput" type="url" placeholder="https://example.com/ai_tr_config.json" required />
+          </label>
+          <div class="btn-row" style="margin-top:8px">
+            <button type="button" id="cancelImportUrl" class="btn">取消</button>
+            <button type="submit" class="btn primary">导入</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+
+  <!-- 主密码验证模态 -->
+  <div id="mpPromptOverlay" class="modal-overlay" hidden>
+    <div class="modal" role="dialog" aria-modal="true" aria-labelledby="mpPromptTitle">
+      <header class="modal-bar">
+        <h2 id="mpPromptTitle">主密码验证</h2>
+        <div class="flex-gap"></div>
+        <button id="closeMpPrompt" class="btn">关闭 (Esc)</button>
+      </header>
+      <div class="modal-body">
+        <form id="mpPromptForm">
+          <label>请输入导入配置的主密码以验证解锁
+            <input id="mpPromptInput" type="password" placeholder="主密码" autocomplete="new-password" required />
+          </label>
+          <div class="btn-row" style="margin-top:8px">
+            <button type="button" id="cancelMpPrompt" class="btn">取消</button>
+            <button type="submit" class="btn primary">确定</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
 
   <script type="module" src="js/theme.js"></script>
   <script type="module" src="js/ui-translate.js"></script>

--- a/index.html
+++ b/index.html
@@ -38,6 +38,7 @@
             <label>名称 <input id="svcName" type="text" placeholder="服务名称"/></label>
             <button type="button" id="btnAddSvc" class="btn">新增配置</button>
             <button type="button" id="btnDelSvc" class="btn danger">删除配置</button>
+            <button type="submit" class="btn primary">保存</button>
           </div>
         </fieldset>
         <fieldset><legend>全局</legend>
@@ -68,7 +69,6 @@
       </form>
       <div class="settings-actions">
         <div class="btn-row">
-          <button type="submit" form="settingsForm" class="btn primary">保存</button>
           <button type="button" id="btnTest" class="btn">连通性测试</button>
           <button type="button" id="btnExport" class="btn">导出(含密文)</button>
           <button type="button" id="btnExportSafe" class="btn">安全导出(不含Key)</button>

--- a/index.html
+++ b/index.html
@@ -1,63 +1,86 @@
-<!DOCTYPE html><html lang="zh-cn"><head><meta charset="UTF-8"/><meta name="viewport" content="width=device-width,initial-scale=1"/><title>AI Translator</title><link rel="stylesheet" href="css/base.css"/><link rel="manifest" href="manifest.webmanifest"/><meta name="theme-color" content="#0d0f11"/><meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self' https:; style-src 'self' 'unsafe-inline'; script-src 'self';"/></head>
+﻿<!DOCTYPE html>
+<html lang="zh-cn">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>AI Translator</title>
+  <link rel="stylesheet" href="css/base.css" />
+  <link rel="manifest" href="manifest.webmanifest" />
+  <meta name="theme-color" content="#0d0f11" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self' https:; style-src 'self' 'unsafe-inline'; script-src 'self';" />
+  
+</head>
 <body>
-<header class="bar"><h1 class="app-title">AI Translator <small id="buildInfo" style="font-weight:normal;font-size:0.6em;opacity:0.7"></small></h1></header>
-<main class="layout">
-  <section class="controls">
-    <label><select id="serviceSelect"></select></label>
-    <label><select id="langSelect" data-ref="lang"></select></label>
-    <div class="btn-row">
-      <button id="btnTranslate" class="btn primary">翻译 (Ctrl+Enter)</button>
-      <button id="btnClear" class="btn">清空</button>
-      <button id="btnCopy" class="btn">复制结果</button>
-      <nav><button id="openSettings" class="btn">设置</button></nav>
+  <header class="bar">
+    <h1 class="app-title">AI Translator <small id="buildInfo" style="font-weight:normal;font-size:0.6em;opacity:0.7"></small></h1>
+    <div class="bar-tools">
+      <button id="btnThemeToggle" class="icon-btn" type="button" title="自动（跟随系统）" aria-label="自动（跟随系统）" aria-pressed="false"></button>
     </div>
-  </section>
-  <section class="panes">
-    <div class="pane">
+  </header>
+  <main class="layout">
+    <section class="controls">
+      <label><select id="serviceSelect"></select></label>
+      <label><select id="langSelect" data-ref="lang"></select></label>
+      <div class="btn-row">
+        <button id="btnTranslate" class="btn primary">翻译 (Ctrl+Enter)</button>
+        <button id="btnClear" class="btn">清空</button>
+        <button id="btnCopy" class="btn">复制结果</button>
+        <nav><button id="openSettings" class="btn">设置</button></nav>
+      </div>
+    </section>
+    <section class="panes">
+      <div class="pane">
       <textarea id="inputText" placeholder="在此粘贴或拖拽待翻译文本（含 .txt 文件）" spellcheck="false"></textarea>
-    </div>
-    <div class="pane">
+      </div>
+      <div class="pane">
       <textarea id="outputText" readonly placeholder="译文输出 (流式)..."></textarea>
-    </div>
-  </section>
-  <section class="status" id="statusBar" aria-live="polite">待机</section>
-</main>
-<!-- 设置模态 -->
-<div id="settingsOverlay" class="modal-overlay" hidden>
-  <div class="modal" role="dialog" aria-modal="true" aria-labelledby="settingsTitle">
-    <header class="modal-bar">
-      <h2 id="settingsTitle">设置</h2>
-      <div class="flex-gap"></div>
-      <button id="closeSettings" class="btn">关闭 (Esc)</button>
-    </header>
-    <div class="modal-body settings-body">
-      <form id="settingsForm">
-        <fieldset><legend>服务配置</legend>
-          <div class="btn-row" style="gap:.5rem;align-items:flex-end;flex-wrap:wrap">
-            <label>当前服务 <select id="svcSelect"></select></label>
-            <label>名称 <input id="svcName" type="text" placeholder="服务名称"/></label>
-            <button type="button" id="btnAddSvc" class="btn">新增配置</button>
-            <button type="button" id="btnDelSvc" class="btn danger">删除配置</button>
-            <button type="submit" class="btn primary">保存</button>
-          </div>
-        </fieldset>
-        <fieldset><legend>全局</legend>
-          <label>主密码 (解锁用) <input name="masterPassword" id="masterPassword" data-field="masterPassword" type="password" placeholder="留空则使用默认密钥" autocomplete="new-password"/></label>
-          <label>默认目标语言 <select name="targetLanguage" data-field="targetLanguage"></select></label>
-          <label>主题 <select name="theme" data-field="theme"><option value="system">跟随系统</option><option value="light">亮色</option><option value="dark">暗色</option></select></label>
-          <label>Prompt 模板</label>
-          <textarea name="promptTemplate" data-field="promptTemplate" rows="10" placeholder="Prompt 模板"></textarea>
-        </fieldset>
-        <fieldset><legend>基础</legend>
-          <label>API 类型 <select name="apiType" data-field="apiType">
-            <option value="openai-responses">OpenAI Responses API</option>
-            <option value="openai-chat">OpenAI Chat Completions</option>
-            <option value="claude">Claude (Anthropic)</option>
-          </select></label>
-          <label>Base URL <input name="baseUrl" data-field="baseUrl" placeholder="https://api.openai.com/v1" required/></label>
-          <label>API Key <input name="apiKey" data-field="apiKey" type="password" placeholder="sk-..." autocomplete="off"/></label>
-          <label>模型 <input name="model" data-field="model" placeholder="gpt-4o-mini / claude-3-5-sonnet"/></label>
-        </fieldset>
+      </div>
+    </section>
+    <section class="status" id="statusBar" aria-live="polite">就绪</section>
+  </main>
+
+  <!-- 设置模态 -->
+  <div id="settingsOverlay" class="modal-overlay" hidden>
+    <div class="modal" role="dialog" aria-modal="true" aria-labelledby="settingsTitle">
+      <header class="modal-bar">
+        <h2 id="settingsTitle">设置</h2>
+        <div class="flex-gap"></div>
+        <button id="closeSettings" class="btn">关闭 (Esc)</button>
+      </header>
+      <div class="modal-body settings-body">
+        <form id="settingsForm">
+          <fieldset>
+            <legend>服务管理</legend>
+            <div class="btn-row" style="gap:.5rem;align-items:flex-end;flex-wrap:wrap">
+              <label>当前服务 <select id="svcSelect"></select></label>
+              <label>名称 <input id="svcName" type="text" placeholder="服务名称"/></label>
+              <button type="button" id="btnAddSvc" class="btn">新增配置</button>
+              <button type="button" id="btnDelSvc" class="btn danger">删除配置</button>
+              <button type="submit" class="btn primary">保存</button>
+            </div>
+          </fieldset>
+
+          <fieldset>
+            <legend>全局</legend>
+            <label>主密码（可选） <input name="masterPassword" id="masterPassword" data-field="masterPassword" type="password" placeholder="留空则使用默认密钥" autocomplete="new-password" /></label>
+            <label>默认目标语言 <select name="targetLanguage" data-field="targetLanguage"></select></label>
+            <label>Prompt 模板</label>
+            <textarea name="promptTemplate" data-field="promptTemplate" rows="10" placeholder="Prompt 模板"></textarea>
+          </fieldset>
+
+          <fieldset>
+            <legend>服务</legend>
+            <label>API 类型
+              <select name="apiType" data-field="apiType">
+                <option value="openai-responses">OpenAI Responses API</option>
+                <option value="openai-chat">OpenAI Chat Completions</option>
+                <option value="claude">Claude (Anthropic)</option>
+              </select>
+            </label>
+            <label>Base URL <input name="baseUrl" data-field="baseUrl" placeholder="https://api.openai.com/v1" required /></label>
+            <label>API Key <input name="apiKey" data-field="apiKey" type="password" placeholder="sk-..." autocomplete="off" /></label>
+            <label>模型 <input name="model" data-field="model" placeholder="gpt-4o-mini / claude-3-5-sonnet" /></label>
+          </fieldset>
         <fieldset><legend>高级</legend>
           <label>流式输出 <input type="checkbox" name="stream" data-field="stream"/></label>
           <label>Temperature <input type="number" step="0.1" min="0" max="2" name="temperature" data-field="temperature"/></label>
@@ -65,26 +88,36 @@
           <label>超时(ms) <input type="number" min="1000" name="timeoutMs" data-field="timeoutMs" placeholder="30000"/></label>
           <label>重试次数 <input type="number" min="0" max="5" name="retries" data-field="retries" placeholder="2"/></label>
           <label>Store Responses <input type="checkbox" name="storeResponses" data-field="storeResponses"/></label>
-        </fieldset>
-      </form>
-      <div class="settings-actions">
-        <div class="btn-row">
-          <button type="button" id="btnTest" class="btn">连通性测试</button>
-          <button type="button" id="btnExport" class="btn">导出(含密文)</button>
-          <button type="button" id="btnExportSafe" class="btn">安全导出(不含Key)</button>
-          <button type="button" id="btnImport" class="btn">导入</button>
-          <button type="button" id="btnImportUrl" class="btn">URL导入</button>
-          <button type="button" id="btnNewSession" class="btn">新建会话</button>
-          <button type="button" id="btnDeleteSession" class="btn danger">删除会话</button>
+          </fieldset>
+        </form>
+
+        <div class="settings-actions" aria-label="设置操作">
+          <button id="toggleSettingsActions" class="btn icon-only" type="button" title="收起/展开" aria-label="收起/展开" aria-pressed="false" style="align-self:flex-end">
+            <span class="icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M8 9l4 4 4-4"/></svg>
+            </span>
+          </button>
+          <div class="btn-row">
+            <button type="button" id="btnTest" class="btn" title="连通性测试"><span class="icon" aria-hidden="true"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2v6M12 16v6M4 12h6M14 12h6"/></svg></span><span class="label">连通性测试</span></button>
+            <button type="button" id="btnExport" class="btn" title="导出(包含密钥)"><span class="icon" aria-hidden="true"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v8M8 9l4-4 4 4"/><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/></svg></span><span class="label">导出(包含密钥)</span></button>
+            <button type="button" id="btnExportSafe" class="btn" title="导出(移除密钥)"><span class="icon" aria-hidden="true"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v8M8 9l4-4 4 4"/><path d="M3 15h18"/></svg></span><span class="label">导出(移除密钥)</span></button>
+            <button type="button" id="btnImport" class="btn" title="导入"><span class="icon" aria-hidden="true"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 19V11M16 15l-4 4-4-4"/><path d="M21 9V5a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v4"/></svg></span><span class="label">导入</span></button>
+            <button type="button" id="btnImportUrl" class="btn" title="URL导入"><span class="icon" aria-hidden="true"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 0 1 0-7l1-1a5 5 0 0 1 7 7l-1 1"/><path d="M14 11a5 5 0 0 1 0 7l-1 1a5 5 0 0 1-7-7l1-1"/></svg></span><span class="label">URL导入</span></button>
+            <button type="button" id="btnNewSession" class="btn" title="新建会话"><span class="icon" aria-hidden="true"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14M5 12h14"/></svg></span><span class="label">新建会话</span></button>
+            <button type="button" id="btnDeleteSession" class="btn danger" title="删除会话"><span class="icon" aria-hidden="true"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/><line x1="10" y1="11" x2="10" y2="17"/><line x1="14" y1="11" x2="14" y2="17"/></svg></span><span class="label">删除会话</span></button>
+          </div>
+          <input type="file" id="importFile" accept="application/json" hidden />
+          <section id="settingsStatus" class="status" aria-live="polite">未修改</section>
         </div>
-        <input type="file" id="importFile" accept="application/json" hidden />
-        <section id="settingsStatus" class="status" aria-live="polite">未修改</section>
       </div>
     </div>
   </div>
-</div>
-<script type="module" src="js/theme.js"></script>
-<script type="module" src="js/ui-translate.js"></script>
-<script type="module" src="js/ui-settings-modal.js"></script>
-<script type="module" src="js/pwa.js"></script>
-</body></html>
+
+  
+
+  <script type="module" src="js/theme.js"></script>
+  <script type="module" src="js/ui-translate.js"></script>
+  <script type="module" src="js/ui-settings-modal.js"></script>
+  <script type="module" src="js/pwa.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
       <div class="flex-gap"></div>
       <button id="closeSettings" class="btn">关闭 (Esc)</button>
     </header>
-    <div class="modal-body">
+    <div class="modal-body settings-body">
       <form id="settingsForm">
         <fieldset><legend>服务配置</legend>
           <div class="btn-row" style="gap:.5rem;align-items:flex-end;flex-wrap:wrap">
@@ -43,6 +43,7 @@
         <fieldset><legend>全局</legend>
           <label>主密码 (解锁用) <input name="masterPassword" id="masterPassword" data-field="masterPassword" type="password" placeholder="留空则使用默认密钥" autocomplete="new-password"/></label>
           <label>默认目标语言 <select name="targetLanguage" data-field="targetLanguage"></select></label>
+          <label>主题 <select name="theme" data-field="theme"><option value="system">跟随系统</option><option value="light">亮色</option><option value="dark">暗色</option></select></label>
           <label>Prompt 模板</label>
           <textarea name="promptTemplate" data-field="promptTemplate" rows="10" placeholder="Prompt 模板"></textarea>
         </fieldset>
@@ -54,7 +55,7 @@
           </select></label>
           <label>Base URL <input name="baseUrl" data-field="baseUrl" placeholder="https://api.openai.com/v1" required/></label>
           <label>API Key <input name="apiKey" data-field="apiKey" type="password" placeholder="sk-..." autocomplete="off"/></label>
-          <label>模型 <input name="model" data-field="model" placeholder="gpt-4o-mini / claude-3-5-sonnet"/></label>
+          <label>模 <input name="model" data-field="model" placeholder="gpt-4o-mini / claude-3-5-sonnet"/></label>
         </fieldset>
         <fieldset><legend>高级</legend>
           <label>流式输出 <input type="checkbox" name="stream" data-field="stream"/></label>
@@ -64,8 +65,10 @@
           <label>重试次数 <input type="number" min="0" max="5" name="retries" data-field="retries" placeholder="2"/></label>
           <label>Store Responses <input type="checkbox" name="storeResponses" data-field="storeResponses"/></label>
         </fieldset>
+      </form>
+      <div class="settings-actions">
         <div class="btn-row">
-          <button type="submit" class="btn primary">保存</button>
+          <button type="submit" form="settingsForm" class="btn primary">保存</button>
           <button type="button" id="btnTest" class="btn">连通性测试</button>
           <button type="button" id="btnExport" class="btn">导出(含密文)</button>
           <button type="button" id="btnExportSafe" class="btn">安全导出(不含Key)</button>
@@ -74,12 +77,14 @@
           <button type="button" id="btnNewSession" class="btn">新建会话</button>
           <button type="button" id="btnDeleteSession" class="btn danger">删除会话</button>
         </div>
-      </form>
-      <input type="file" id="importFile" accept="application/json" hidden />
-      <section id="settingsStatus" class="status" aria-live="polite">未修改</section>
+        <input type="file" id="importFile" accept="application/json" hidden />
+        <section id="settingsStatus" class="status" aria-live="polite">未修改</section>
+      </div>
     </div>
   </div>
 </div>
+<script type="module" src="js/theme.js"></script>
 <script type="module" src="js/ui-translate.js"></script>
-<script type="module" src="js/ui-settings-modal.js"></script><script type="module" src="js/pwa.js"></script>
+<script type="module" src="js/ui-settings-modal.js"></script>
+<script type="module" src="js/pwa.js"></script>
 </body></html>

--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@
           </select></label>
           <label>Base URL <input name="baseUrl" data-field="baseUrl" placeholder="https://api.openai.com/v1" required/></label>
           <label>API Key <input name="apiKey" data-field="apiKey" type="password" placeholder="sk-..." autocomplete="off"/></label>
-          <label>模 <input name="model" data-field="model" placeholder="gpt-4o-mini / claude-3-5-sonnet"/></label>
+          <label>模型 <input name="model" data-field="model" placeholder="gpt-4o-mini / claude-3-5-sonnet"/></label>
         </fieldset>
         <fieldset><legend>高级</legend>
           <label>流式输出 <input type="checkbox" name="stream" data-field="stream"/></label>

--- a/js/config.js
+++ b/js/config.js
@@ -33,7 +33,7 @@ const defaultConfig = {
   maxTokens: undefined,
   timeoutMs: 30000,
   retries: 2,
-  theme: 'system',
+  // theme 已移除，由 UI 侧边栏开关管理（localStorage: AI_TR_THEME_MODE）
   storeResponses: false,
   // 多服务
   services: [
@@ -192,6 +192,7 @@ export function loadConfig(){
 
 export function saveConfig(cfg){
   const clean = { ...defaultConfig, ...cfg };
+  if ('theme' in clean) delete clean.theme; // 主题配置已废弃，不再持久化
   clean.services = normalizeServices(clean.services);
   if (!clean.activeServiceId) clean.activeServiceId = clean.services[0].id;
   if ('masterPassword' in clean) delete clean.masterPassword;

--- a/js/config.js
+++ b/js/config.js
@@ -33,6 +33,7 @@ const defaultConfig = {
   maxTokens: undefined,
   timeoutMs: 30000,
   retries: 2,
+  theme: 'system',
   storeResponses: false,
   // 多服务
   services: [

--- a/js/theme.js
+++ b/js/theme.js
@@ -1,0 +1,29 @@
+import { loadConfig } from './config.js';
+
+const meta = document.querySelector('meta[name="theme-color"]');
+const media = window.matchMedia('(prefers-color-scheme: dark)');
+
+function applyTheme(theme){
+  let mode = theme;
+  if (mode === 'system' || !mode){
+    mode = media.matches ? 'dark' : 'light';
+  }
+  document.documentElement.dataset.theme = mode;
+  if (meta){ meta.setAttribute('content', mode === 'dark' ? '#0d0f11' : '#ffffff'); }
+}
+
+export function initTheme(){
+  const cfg = loadConfig();
+  applyTheme(cfg.theme || 'system');
+  window.addEventListener('ai-tr:config-changed', e=>{
+    applyTheme((e.detail.cfg && e.detail.cfg.theme) || 'system');
+  });
+  const handler = ()=>{
+    const cfg = loadConfig();
+    if ((cfg.theme||'system') === 'system') applyTheme('system');
+  };
+  if (media.addEventListener){ media.addEventListener('change', handler); }
+  else if (media.addListener){ media.addListener(handler); }
+}
+
+initTheme();

--- a/js/theme.js
+++ b/js/theme.js
@@ -1,7 +1,16 @@
-import { loadConfig } from './config.js';
-
 const meta = document.querySelector('meta[name="theme-color"]');
 const media = window.matchMedia('(prefers-color-scheme: dark)');
+const THEME_KEY = 'AI_TR_THEME_MODE'; // 'light' | 'dark' | 'system'
+
+function getStoredTheme(){
+  const v = localStorage.getItem(THEME_KEY);
+  return v === 'light' || v === 'dark' || v === 'system' ? v : 'system';
+}
+
+function setStoredTheme(mode){
+  if (!['light','dark','system'].includes(mode)) mode = 'system';
+  localStorage.setItem(THEME_KEY, mode);
+}
 
 function applyTheme(theme){
   let mode = theme;
@@ -9,21 +18,46 @@ function applyTheme(theme){
     mode = media.matches ? 'dark' : 'light';
   }
   document.documentElement.dataset.theme = mode;
-  if (meta){ meta.setAttribute('content', mode === 'dark' ? '#0d0f11' : '#ffffff'); }
+  if (meta){ meta.setAttribute('content', mode === 'dark' ? '#0d0f11' : '#f6f8fa'); }
+}
+
+function updateToggleUI(active){
+  const btn = document.getElementById('btnThemeToggle');
+  if (!btn) return;
+  const iconSun = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"></circle><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"></path></svg>';
+  const iconMoon = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3a7 7 0 0 0 9.79 9.79z"></path></svg>';
+  const iconSystem = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="4" width="18" height="14" rx="2" ry="2"></rect><path d="M8 21h8"></path></svg>';
+  let label = '自动（跟随系统）';
+  let icon = iconSystem;
+  if (active === 'light'){ label = '亮色主题'; icon = iconSun; }
+  else if (active === 'dark'){ label = '暗色主题'; icon = iconMoon; }
+  else { label = '自动（跟随系统）'; icon = iconSystem; }
+  btn.title = label;
+  btn.setAttribute('aria-label', label);
+  btn.innerHTML = icon;
+  btn.setAttribute('aria-pressed', 'true');
+}
+
+function bindToggleUI(){
+  const btn = document.getElementById('btnThemeToggle');
+  if (!btn) return;
+  const modes = ['light','dark','system'];
+  const setMode = (m)=>{ setStoredTheme(m); applyTheme(m); updateToggleUI(m); };
+  btn.addEventListener('click', ()=>{
+    const cur = getStoredTheme();
+    const idx = modes.indexOf(cur);
+    const next = modes[(idx + 1) % modes.length] || 'system';
+    setMode(next);
+  });
+  updateToggleUI(getStoredTheme());
 }
 
 export function initTheme(){
-  const cfg = loadConfig();
-  applyTheme(cfg.theme || 'system');
-  window.addEventListener('ai-tr:config-changed', e=>{
-    applyTheme((e.detail.cfg && e.detail.cfg.theme) || 'system');
-  });
-  const handler = ()=>{
-    const cfg = loadConfig();
-    if ((cfg.theme||'system') === 'system') applyTheme('system');
-  };
+  applyTheme(getStoredTheme());
+  const handler = ()=>{ if (getStoredTheme()==='system') applyTheme('system'); };
   if (media.addEventListener){ media.addEventListener('change', handler); }
   else if (media.addListener){ media.addListener(handler); }
+  bindToggleUI();
 }
 
 initTheme();

--- a/js/ui-settings-modal.js
+++ b/js/ui-settings-modal.js
@@ -47,6 +47,13 @@ function applyActionsCollapsed(on){
   actionsPanel.classList.toggle('collapsed', !!on);
   if (toggleActions) toggleActions.setAttribute('aria-pressed', on ? 'true':'false');
 }
+// Utility: check if any child overlay (e.g., URL/master password) is open
+function hasActiveSubOverlay(){
+  const u = document.getElementById('importUrlOverlay');
+  const m = document.getElementById('mpPromptOverlay');
+  return (!!u && !u.hidden) || (!!m && !m.hidden);
+}
+
 try {
   const initCollapsed = localStorage.getItem(COLLAPSE_KEY) === '1';
   applyActionsCollapsed(initCollapsed);
@@ -125,7 +132,9 @@ function close(){ overlay.hidden=true; unlockBodyScroll(overlay); }
 openBtn.addEventListener('click', open);
 closeBtn.addEventListener('click', close);
 overlay.addEventListener('click', e=>{ if (e.target===overlay) close(); });
-window.addEventListener('keydown', e=>{ if (e.key==='Escape' && !overlay.hidden) close(); });
+window.addEventListener('keydown', e=>{
+  if (e.key==='Escape' && !overlay.hidden && !hasActiveSubOverlay()) close();
+});
 
 form.addEventListener('submit', async e=>{
   e.preventDefault();

--- a/js/ui-settings-modal.js
+++ b/js/ui-settings-modal.js
@@ -275,6 +275,76 @@ btnTest.addEventListener('click', async()=>{
 btnExport.addEventListener('click', ()=> exportConfig(loadConfig()));
 btnExportSafe.addEventListener('click', ()=> exportConfig(loadConfig(), { safe:true }));
 btnImport.addEventListener('click', ()=> importFile.click());
+
+// ===== 简易模态：URL 输入 & 主密码验证 =====
+const urlOverlay = document.getElementById('importUrlOverlay');
+const urlForm = document.getElementById('importUrlForm');
+const urlInput = document.getElementById('importUrlInput');
+const urlClose = document.getElementById('closeImportUrl');
+const urlCancel = document.getElementById('cancelImportUrl');
+
+const mpOverlay = document.getElementById('mpPromptOverlay');
+const mpForm = document.getElementById('mpPromptForm');
+const mpInputEl = document.getElementById('mpPromptInput');
+const mpClose = document.getElementById('closeMpPrompt');
+const mpCancel = document.getElementById('cancelMpPrompt');
+
+function openOverlay(overlayEl, focusEl){
+  overlayEl.hidden = false;
+  document.body.style.overflow = 'hidden';
+  setTimeout(()=> focusEl?.focus(), 0);
+}
+function closeOverlay(overlayEl){
+  overlayEl.hidden = true;
+  document.body.style.overflow = '';
+}
+
+function getUrlByModal(){
+  return new Promise((resolve)=>{
+    const onSubmit = (e)=>{ e.preventDefault(); const v = String(urlInput.value||'').trim(); resolve(v||''); cleanup(); };
+    const onCancel = ()=>{ resolve(''); cleanup(); };
+    const onOverlay = (e)=>{ if (e.target===urlOverlay) { resolve(''); cleanup(); } };
+    const onEsc = (e)=>{ if (e.key==='Escape') { resolve(''); cleanup(); } };
+    function cleanup(){
+      urlForm.removeEventListener('submit', onSubmit);
+      urlCancel.removeEventListener('click', onCancel);
+      urlClose.removeEventListener('click', onCancel);
+      urlOverlay.removeEventListener('click', onOverlay);
+      window.removeEventListener('keydown', onEsc);
+      closeOverlay(urlOverlay);
+    }
+    urlForm.addEventListener('submit', onSubmit);
+    urlCancel.addEventListener('click', onCancel);
+    urlClose.addEventListener('click', onCancel);
+    urlOverlay.addEventListener('click', onOverlay);
+    window.addEventListener('keydown', onEsc);
+    openOverlay(urlOverlay, urlInput);
+  });
+}
+
+function getMasterPasswordByModal(){
+  return new Promise((resolve, reject)=>{
+    const onSubmit = (e)=>{ e.preventDefault(); const v = String(mpInputEl.value||'').trim(); if (!v){ mpInputEl.focus(); return; } resolve(v); cleanup(); };
+    const onCancel = ()=>{ reject(new Error('已取消')); cleanup(); };
+    const onOverlay = (e)=>{ if (e.target===mpOverlay) { onCancel(); } };
+    const onEsc = (e)=>{ if (e.key==='Escape') { onCancel(); } };
+    function cleanup(){
+      mpForm.removeEventListener('submit', onSubmit);
+      mpCancel.removeEventListener('click', onCancel);
+      mpClose.removeEventListener('click', onCancel);
+      mpOverlay.removeEventListener('click', onOverlay);
+      window.removeEventListener('keydown', onEsc);
+      mpInputEl.value = '';
+      closeOverlay(mpOverlay);
+    }
+    mpForm.addEventListener('submit', onSubmit);
+    mpCancel.addEventListener('click', onCancel);
+    mpClose.addEventListener('click', onCancel);
+    mpOverlay.addEventListener('click', onOverlay);
+    window.addEventListener('keydown', onEsc);
+    openOverlay(mpOverlay, mpInputEl);
+  });
+}
 async function applyImported(imported, prevCfgRaw, prevApiMeta, prevMpMeta){
   try {
     if (imported.__masterPasswordMeta){ try { localStorage.setItem(MP_META_KEY, JSON.stringify(imported.__masterPasswordMeta)); } catch { /* ignore */ } }
@@ -287,10 +357,7 @@ async function applyImported(imported, prevCfgRaw, prevApiMeta, prevMpMeta){
     }
     if (imported.__apiKeyMeta){ try { localStorage.setItem(ENC_META_KEY, JSON.stringify(imported.__apiKeyMeta)); } catch { /* ignore */ } }
     if (imported.masterPasswordEnc){
-      let mp = prompt('请输入导入配置的主密码以验证解锁');
-      if (mp == null){ throw new Error('已取消'); }
-      mp = mp.trim();
-      if (!mp){ throw new Error('主密码为空'); }
+      let mp = await getMasterPasswordByModal();
       try { const plainMp = await decryptMasterPassword(imported.masterPasswordEnc); if (plainMp !== mp){ throw new Error('主密码不匹配'); } } catch(e){ throw new Error('主密码验证失败'); }
       if (Array.isArray(imported.services)){
         for (const s of imported.services){ if (s.apiKeyEnc){ try { await decryptApiKey(s.apiKeyEnc, mp, s.id); } catch(e){ throw new Error(`服务 ${s.name||s.id} API Key 解密失败`); } } }
@@ -332,7 +399,7 @@ importFile.addEventListener('change', async()=>{
 });
 
 btnImportUrl.addEventListener('click', async()=>{
-  const input = prompt('请输入配置 URL');
+  const input = await getUrlByModal();
   if (!input) return;
   let url;
   try { url = new URL(input.trim()); }

--- a/js/ui-settings-modal.js
+++ b/js/ui-settings-modal.js
@@ -15,6 +15,27 @@ const btnImport = document.getElementById('btnImport');
 const btnImportUrl = document.getElementById('btnImportUrl');
 const btnNewSession = document.getElementById('btnNewSession');
 const btnDeleteSession = document.getElementById('btnDeleteSession');
+// actions sidebar collapse
+const actionsPanel = document.querySelector('.settings-actions');
+const toggleActions = document.getElementById('toggleSettingsActions');
+const COLLAPSE_KEY = 'AI_TR_SETTINGS_ACTIONS_COLLAPSED';
+
+function applyActionsCollapsed(on){
+  if (!actionsPanel) return;
+  actionsPanel.classList.toggle('collapsed', !!on);
+  if (toggleActions) toggleActions.setAttribute('aria-pressed', on ? 'true':'false');
+}
+try {
+  const initCollapsed = localStorage.getItem(COLLAPSE_KEY) === '1';
+  applyActionsCollapsed(initCollapsed);
+} catch {}
+if (toggleActions){
+  toggleActions.addEventListener('click', ()=>{
+    const now = !(actionsPanel && actionsPanel.classList.contains('collapsed'));
+    applyActionsCollapsed(now);
+    try { localStorage.setItem(COLLAPSE_KEY, now ? '1':'0'); } catch {}
+  });
+}
 // 多服务 UI
 const svcSelect = document.getElementById('svcSelect');
 const svcName = document.getElementById('svcName');

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -74,6 +74,7 @@ async function run({ watch=false }={}){
     entryPoints: [
       path.join(root,'js','ui-translate.js'),
       path.join(root,'js','ui-settings-modal.js'),
+      path.join(root,'js','theme.js'),
       // path.join(root,'js','ui-settings.js'),
       path.join(root,'js','api.js'),
       path.join(root,'js','config.js'),

--- a/sw.js
+++ b/sw.js
@@ -4,6 +4,7 @@ const CORE_ASSETS = [
   './css/base.css',
   './js/ui-translate.js',
   './js/ui-settings-modal.js',
+  './js/theme.js',
   './js/pwa.js',
   './manifest.webmanifest',
   './default.prompt',


### PR DESCRIPTION
## Summary
- move settings modal action buttons into a right-hand sidebar for clearer layout
- add light color theme with options to switch between light, dark, or system theme
- implement theme module and integrate with service worker/build pipeline

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bcfce5ab00832cbf7d630658b4ed11