### PR TITLE
fix: prevent dark flash on light theme reload

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,10 +4,11 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>AI Translator</title>
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self' https:; style-src 'self' 'unsafe-inline'; script-src 'self';" />
+  <meta name="theme-color" content="#0d0f11" />
+  <script src="js/theme-init.js"></script>
   <link rel="stylesheet" href="css/base.css" />
   <link rel="manifest" href="manifest.webmanifest" />
-  <meta name="theme-color" content="#0d0f11" />
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self' https:; style-src 'self' 'unsafe-inline'; script-src 'self';" />
   
 </head>
 <body>

--- a/js/theme-init.js
+++ b/js/theme-init.js
@@ -1,0 +1,12 @@
+(function(){
+  const THEME_KEY = 'AI_TR_THEME_MODE';
+  const meta = document.querySelector('meta[name="theme-color"]');
+  let mode = localStorage.getItem(THEME_KEY);
+  if (mode !== 'light' && mode !== 'dark') {
+    mode = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  }
+  document.documentElement.dataset.theme = mode;
+  if (meta) {
+    meta.setAttribute('content', mode === 'dark' ? '#0d0f11' : '#f6f8fa');
+  }
+})();

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -43,7 +43,7 @@ function copyDir(srcDir, destDir){
 }
 
 function copyStatics(){
-  const staticFiles = ['index.html', 'default.prompt',"favicon.png",'manifest.webmanifest','sw.js'];
+  const staticFiles = ['index.html', 'default.prompt',"favicon.png",'manifest.webmanifest','sw.js','js/theme-init.js'];
   for (const f of staticFiles){ const src = path.join(root, f); if (fs.existsSync(src)) copyFile(src, path.join(distDir, f)); }
   copyDir(path.join(root,'assets'), path.join(distDir,'assets'));
   copyDir(path.join(root,'css'), path.join(distDir,'css'));


### PR DESCRIPTION
## Summary
- initialize stored or system theme early to avoid dark flash on page refresh
- copy new early-theme script during build

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68be9b246508832ca14bdc6d790d18f2