### PR TITLE
Fix undo in input and select-all in output area

### DIFF
--- a/js/ui-translate.js
+++ b/js/ui-translate.js
@@ -15,6 +15,19 @@ const btnTranslate = document.getElementById('btnTranslate');
 const btnClear = document.getElementById('btnClear');
 const btnCopy = document.getElementById('btnCopy');
 
+// 支持在输出区域使用 Ctrl+A 仅选择翻译结果
+outputView?.addEventListener('keydown', e => {
+  if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'a') {
+    e.preventDefault();
+    const sel = window.getSelection();
+    if (!sel) return;
+    const range = document.createRange();
+    range.selectNodeContents(outputView);
+    sel.removeAllRanges();
+    sel.addRange(range);
+  }
+});
+
 const LANGS = [
   ['zh-CN','中文'],['en','English'],['ja','日本語'],['ko','한국어'],['fr','Français'],['de','Deutsch']
 ];
@@ -76,15 +89,19 @@ function tsvToMarkdownIfTable(text){
   return [toLine(header), toLine(sep), ...body.map(toLine)].join('\n');
 }
 
-// 在 textarea 光标处插入文本
-function insertAtCursor(textarea, text){
-  const start = textarea.selectionStart ?? textarea.value.length;
-  const end = textarea.selectionEnd ?? textarea.value.length;
-  const before = textarea.value.slice(0, start);
-  const after = textarea.value.slice(end);
-  textarea.value = before + text + after;
-  const pos = start + text.length;
-  textarea.selectionStart = textarea.selectionEnd = pos;
+// 替换输入框全部文本并尽量保留撤销栈
+function replaceInput(text){
+  inputEl.focus();
+  inputEl.select();
+  let ok = false;
+  try {
+    ok = document.execCommand('insertText', false, text);
+  } catch (e) {
+    ok = false;
+  }
+  if (!ok) {
+    inputEl.setRangeText(text, 0, inputEl.value.length, 'end');
+  }
 }
 
 // 粘贴模式：'plain' 或 'markdown'
@@ -231,7 +248,6 @@ inputEl.addEventListener('dragover', e=>{ e.preventDefault(); });
 inputEl.addEventListener('drop', e=>{
   e.preventDefault();
   // 需求：拖拽前先清空输入与输出
-  inputEl.value = '';
   outputRaw = '';
   renderMarkdown('');
   const dt = e.dataTransfer;
@@ -246,7 +262,7 @@ inputEl.addEventListener('drop', e=>{
       f.name.endsWith('.markdown')
     ){
       const reader = new FileReader();
-      reader.onload = ()=>{ inputEl.value = reader.result; setStatus('文件已载入'); };
+      reader.onload = ()=>{ replaceInput(reader.result); setStatus('文件已载入'); };
       reader.readAsText(f);
     } else {
       setStatus('仅支持 .txt / .md');
@@ -257,34 +273,33 @@ inputEl.addEventListener('drop', e=>{
   const text = dt.getData('text/plain');
   if (mode==='markdown'){
     const md = dt.getData('text/markdown');
-    if (md){ inputEl.value = md; setStatus('Markdown 已载入'); return; }
+    if (md){ replaceInput(md); setStatus('Markdown 已载入'); return; }
     const html = dt.getData('text/html');
-    if (html){ const md2 = turndown.turndown(html); inputEl.value = md2; setStatus('HTML 已转换为 Markdown'); return; }
-  const mdFromTsv = tsvToMarkdownIfTable(text);
-  if (mdFromTsv){ inputEl.value = mdFromTsv; setStatus('检测到表格 (TSV) · 已转换为 Markdown'); return; }
+    if (html){ const md2 = turndown.turndown(html); replaceInput(md2); setStatus('HTML 已转换为 Markdown'); return; }
+    const mdFromTsv = tsvToMarkdownIfTable(text);
+    if (mdFromTsv){ replaceInput(mdFromTsv); setStatus('检测到表格 (TSV) · 已转换为 Markdown'); return; }
   }
-  if (text){ inputEl.value = text; setStatus('文本已载入'); }
+  if (text){ replaceInput(text); setStatus('文本已载入'); }
 });
 
 // 粘贴事件：保留 Markdown（或将 HTML 转为 Markdown）
 inputEl.addEventListener('paste', (e)=>{
   const cd = e.clipboardData; if (!cd) return;
   // 需求：粘贴前先清空输入与输出
-  inputEl.value = '';
   outputRaw = '';
   renderMarkdown('');
   const mode = getPasteMode();
   const text = cd.getData('text/plain');
   if (mode==='markdown'){
     const md = cd.getData('text/markdown');
-    if (md){ e.preventDefault(); inputEl.value = md; setStatus('已粘贴 Markdown'); return; }
+    if (md){ e.preventDefault(); replaceInput(md); setStatus('已粘贴 Markdown'); return; }
     const html = cd.getData('text/html');
-    if (html){ e.preventDefault(); const md2 = turndown.turndown(html); inputEl.value = md2; setStatus('已从 HTML 转 Markdown'); return; }
-  const mdFromTsv = tsvToMarkdownIfTable(text);
-  if (mdFromTsv){ e.preventDefault(); inputEl.value = mdFromTsv; setStatus('检测到表格 (TSV) · 已转换为 Markdown'); return; }
+    if (html){ e.preventDefault(); const md2 = turndown.turndown(html); replaceInput(md2); setStatus('已从 HTML 转 Markdown'); return; }
+    const mdFromTsv = tsvToMarkdownIfTable(text);
+    if (mdFromTsv){ e.preventDefault(); replaceInput(mdFromTsv); setStatus('检测到表格 (TSV) · 已转换为 Markdown'); return; }
   }
   // 否则默认（纯文本）
-  if (text){ e.preventDefault(); inputEl.value = text; setStatus('已粘贴文本'); }
+  if (text){ e.preventDefault(); replaceInput(text); setStatus('已粘贴文本'); }
 });
 
 (function init(){


### PR DESCRIPTION
## Summary
- Preserve input history by inserting dropped or pasted text via `execCommand` with fallback so Ctrl+Z works
- Allow Ctrl+A to select only translation output instead of whole page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68be9dca7040832cbfcbfc8a1121613f