### PR TITLE
Fix mobile layout of settings actions

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -77,7 +77,19 @@ input:focus,select:focus{outline:2px solid var(--accent);outline-offset:0}
 .modal-body.settings-body{flex-direction:row;align-items:flex-start}
 .settings-body form{flex:1}
 .flex-gap{flex:1}
-@media (max-width:820px){.modal{max-width:100%;height:100%;border-radius:0}.modal-body{max-height:unset;height:100%;}.modal-body.settings-body{flex-direction:column}}
+@media (max-width:820px){
+  .modal{max-width:100%;height:100%;border-radius:0}
+  .modal-body{max-height:unset;height:100%;}
+  .modal-body.settings-body{flex-direction:column}
+  .modal-body.settings-body .settings-actions{
+    order:-1;
+    flex-direction:row;
+    flex-wrap:wrap
+  }
+  .modal-body.settings-body .settings-actions .btn{width:auto}
+  .modal-body.settings-body .settings-actions .btn-row{flex-direction:row}
+  .modal-body.settings-body .settings-actions .status{margin-top:0}
+}
 @media (max-width:900px){.panes{grid-template-columns:1fr;grid-template-rows:minmax(0,1fr) minmax(0,1fr)}.controls{flex-direction:column;align-items:stretch}}
 
 /* Side tools removed: theme toggle moved to header */

--- a/css/base.css
+++ b/css/base.css
@@ -84,7 +84,7 @@ input:focus,select:focus{outline:2px solid var(--accent);outline-offset:0}
   .modal-body.settings-body .settings-actions{
     order:-1;
     flex-direction:row;
-    flex-wrap:wrap
+    flex-wrap:wrap;
   }
   .modal-body.settings-body .settings-actions .btn{width:auto}
   .modal-body.settings-body .settings-actions .btn-row{flex-direction:row}


### PR DESCRIPTION
## Summary
- keep settings action buttons pinned above the form on narrow screens
- lay out settings action buttons horizontally below 820px width

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c0f51b630c832cafa58fd499aa3ae2