### PR TITLE
Add vision toggle and image upload support

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -7,6 +7,12 @@ body{display:flex;flex-direction:column;min-height:600px}
 .app-title{margin:0;font-size:16px;font-weight:600}
 .layout{width:100%;max-width:1200px;margin:0 auto;padding:var(--gap);flex:1;display:flex;flex-direction:column;gap:var(--gap);min-height:0}
 .controls{display:flex;flex-wrap:wrap;align-items:flex-end;gap:var(--gap)}
+.attachment-bar{display:flex;flex-direction:column;gap:6px;width:100%}
+.attachment-list{display:flex;flex-wrap:wrap;gap:8px;margin-top:2px}
+.attachment-chip{display:inline-flex;align-items:center;gap:6px;background:var(--surface);border:1px solid var(--border);border-radius:var(--radius);padding:6px 8px;font-size:12px}
+.attachment-chip .chip-name{max-width:220px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.attachment-chip button{background:none;border:none;color:var(--fg-dim);cursor:pointer;padding:4px;border-radius:var(--radius)}
+.attachment-chip button:hover{color:var(--fg);background:var(--surface-alt)}
 .btn-row{display:flex;flex-wrap:wrap;gap:var(--gap)}
 .btn{background:var(--surface);color:var(--fg);border:1px solid var(--border);padding:6px 14px;border-radius:var(--radius);cursor:pointer;font:inherit;font-size:14px}
 .btn.primary{background:var(--accent);color:#fff;border:none}

--- a/index.html
+++ b/index.html
@@ -31,6 +31,14 @@
         <button id="btnCopy" class="btn">复制</button>
         <nav><button id="openSettings" class="btn">设置</button></nav>
       </div>
+      <div class="attachment-bar" aria-label="图片输入">
+        <div class="btn-row" style="align-items:center">
+          <button id="btnAddImage" class="btn" type="button">添加图片</button>
+          <span id="visionHint" class="status" aria-live="polite"></span>
+        </div>
+        <input type="file" id="imagePicker" accept="image/*" multiple hidden />
+        <div id="imageList" class="attachment-list" aria-live="polite"></div>
+      </div>
     </section>
     <section class="panes">
       <div class="pane">
@@ -94,6 +102,7 @@
             <label>Base URL <input name="baseUrl" data-field="baseUrl" placeholder="https://api.openai.com/v1" required /></label>
             <label>API Key <input name="apiKey" data-field="apiKey" type="password" placeholder="sk-..." autocomplete="off" /></label>
             <label>模型 <input name="model" data-field="model" placeholder="gpt-4o-mini / claude-3-5-sonnet" /></label>
+            <label>视觉（图片输入） <input type="checkbox" name="vision" data-field="vision" /></label>
           </fieldset>
         <fieldset><legend>高级</legend>
           <label>流式输出 <input type="checkbox" name="stream" data-field="stream"/></label>

--- a/js/api.js
+++ b/js/api.js
@@ -21,6 +21,65 @@ function sanitizeSystem(fullInstr){
   return String(fullInstr).trim();
 }
 
+function normalizeImages(images){
+  if (!Array.isArray(images)) return [];
+  return images
+    .filter(img=>img && img.dataUrl)
+    .map(img=>({
+      dataUrl: img.dataUrl,
+      type: img.type || '',
+      name: img.name || '',
+      size: img.size || 0
+    }));
+}
+
+function parseDataUrl(dataUrl){
+  const m = String(dataUrl||'').match(/^data:([^;]+);base64,(.*)$/);
+  return {
+    mediaType: m?.[1] || 'image/png',
+    data: m?.[2] || ''
+  };
+}
+
+function buildResponsesContent(userText, images){
+  const content = [];
+  if (userText || !images.length) content.push({ type:'input_text', text: userText });
+  for (const img of normalizeImages(images)){
+    content.push({ type:'input_image', image_url: { url: img.dataUrl } });
+  }
+  return content;
+}
+
+function buildChatContent(userText, images){
+  const content = [];
+  if (userText || !images.length) content.push({ type:'text', text: userText });
+  for (const img of normalizeImages(images)){
+    content.push({ type:'image_url', image_url: { url: img.dataUrl } });
+  }
+  return content;
+}
+
+function buildClaudeContent(userText, images){
+  const content = [];
+  if (userText || !images.length) content.push({ type:'text', text: userText });
+  for (const img of normalizeImages(images)){
+    const { mediaType, data } = parseDataUrl(img.dataUrl);
+    content.push({ type:'image', source:{ type:'base64', media_type: mediaType, data } });
+  }
+  return content;
+}
+
+function responsesContentToChat(content){
+  const out = [];
+  for (const item of content||[]){
+    if (item?.type === 'input_text') out.push({ type:'text', text: item.text || '' });
+    else if (item?.type === 'input_image' && item.image_url?.url){
+      out.push({ type:'image_url', image_url:{ url: item.image_url.url } });
+    }
+  }
+  return out;
+}
+
 /**
  * 非流式翻译（v0.1）
  * @param {string} text
@@ -30,20 +89,23 @@ function sanitizeSystem(fullInstr){
 export async function translateOnce(text, opts={}){
   const cfg = getActiveConfig();
   const target = opts.targetLanguage || cfg.targetLanguage;
+  const images = normalizeImages(opts.images);
   if (!cfg.apiKeyEnc) throw makeError('ConfigError','请在设置中填写 API Key');
   let apiKey;
   try { apiKey = await getApiKeyAuto(); }
   catch(e){ if (/主密码不正确/.test(e.message)) throw makeError('AuthError','主密码错误，无法解锁 API Key'); else throw e; }
   if (cfg.apiType === 'openai-responses'){
     const userContent = `<translate_input>${text}</translate_input>`;
-  const instructions = renderTemplate(cfg.promptTemplate, { text, target_language: target });
-  const system = sanitizeSystem(instructions); // 回退 chat 用
+    const instructions = renderTemplate(cfg.promptTemplate, { text, target_language: target });
+    const system = sanitizeSystem(instructions); // 回退 chat 用
+    const inputContent = buildResponsesContent(userContent, images);
+    const chatContent = buildChatContent(userContent, images);
     const payload = {
       model: cfg.model,
       stream: false,
       temperature: Number(cfg.temperature) || 0,
       instructions,
-      input: [ { role: 'user', content: [{ type:'input_text', text: userContent }] } ],
+      input: [ { role: 'user', content: inputContent } ],
       ...(cfg.storeResponses ? { metadata:{ store:true }, previous_response_id: previousResponseId() || undefined } : {})
     };
     let textOut;
@@ -55,28 +117,28 @@ export async function translateOnce(text, opts={}){
     } catch(e){
       // 针对部分老模型或不支持 responses 的情况回退 chat.completions
       if (e.name==='ApiError' && /(Invalid value: 'text'|404|not found|Unknown endpoint)/i.test(e.message)){
-        const chatBody = { model: cfg.model, temperature: cfg.temperature ?? 0, messages:[ { role:'system', content: system }, { role:'user', content: userContent } ] };
+        const chatBody = { model: cfg.model, temperature: cfg.temperature ?? 0, messages:[ { role:'system', content: system }, { role:'user', content: chatContent } ] };
         textOut = await postJsonChat(cfg.baseUrl.replace(/\/$/,'') + '/chat/completions', chatBody, apiKey, cfg.timeoutMs, extractTextFromResponses);
       } else throw e;
     }
     return textOut;
   } else if (cfg.apiType === 'openai-chat') {
     const userContent = `<translate_input>${text}</translate_input>`;
-  const full = renderTemplate(cfg.promptTemplate, { text, target_language: target });
-  const system = sanitizeSystem(full);
-    const chatBody = { model: cfg.model, temperature: cfg.temperature ?? 0, messages:[ { role:'system', content: system }, { role:'user', content: userContent } ] };
+    const full = renderTemplate(cfg.promptTemplate, { text, target_language: target });
+    const system = sanitizeSystem(full);
+    const chatBody = { model: cfg.model, temperature: cfg.temperature ?? 0, messages:[ { role:'system', content: system }, { role:'user', content: buildChatContent(userContent, images) } ] };
     const out = await postJsonChat(cfg.baseUrl.replace(/\/$/,'') + '/chat/completions', chatBody, apiKey, cfg.timeoutMs, extractTextFromResponses);
     return out;
   } else if (cfg.apiType === 'claude') {
-  const full = renderTemplate(cfg.promptTemplate, { text, target_language: target });
-  const system = sanitizeSystem(full);
+    const full = renderTemplate(cfg.promptTemplate, { text, target_language: target });
+    const system = sanitizeSystem(full);
     const user = `<translate_input>${text}</translate_input>\nTarget: ${target}`;
     const payload = {
       model: cfg.model,
       max_tokens: cfg.maxTokens || 2048,
       temperature: cfg.temperature ?? 0,
       system,
-      messages: [ { role:'user', content:[{ type:'text', text: user }] } ]
+      messages: [ { role:'user', content: buildClaudeContent(user, images) } ]
     };
   return await postJsonClaude(cfg.baseUrl.replace(/\/$/,'') + '/messages', payload, apiKey, cfg.timeoutMs, extractTextFromClaudeResponse);
   }
@@ -95,7 +157,11 @@ function extractTextFromResponses(obj){
     if (buf) return buf;
   }
   // 兼容旧 chat.completions
-  if (obj.choices && obj.choices[0]?.message?.content) return obj.choices[0].message.content;
+  if (obj.choices && obj.choices[0]?.message?.content){
+    const cont = obj.choices[0].message.content;
+    if (Array.isArray(cont)) return cont.map(p=>p?.text||p).join('');
+    return cont;
+  }
   return '';
 }
 
@@ -112,15 +178,17 @@ export async function * translateStream(text, opts={}){
   try { apiKey = await getApiKeyAuto(); }
   catch(e){ if (/主密码不正确/.test(e.message)) { throw makeError('AuthError','主密码错误，无法解锁 API Key'); } else throw e; }
   const target = opts.targetLanguage || cfg.targetLanguage;
+  const images = normalizeImages(opts.images);
   if (cfg.apiType === 'openai-responses'){
     const userContent = `<translate_input>${text}</translate_input>`;
     const instructions = renderTemplate(cfg.promptTemplate, { text, target_language: target });
+    const inputContent = buildResponsesContent(userContent, images);
     const payload = {
       model: cfg.model,
       stream: true,
       temperature: Number(cfg.temperature) || 0,
       instructions,
-      input: [ { role: 'user', content: [{ type:'input_text', text: userContent }] } ],
+      input: [ { role: 'user', content: inputContent } ],
       ...(cfg.storeResponses ? { metadata:{ store:true }, previous_response_id: previousResponseId() || undefined } : {})
     };
   yield* streamOpenAI({ ...cfg, apiKey }, payload, opts.signal);
@@ -129,9 +197,9 @@ export async function * translateStream(text, opts={}){
     const userContent = `<translate_input>${text}</translate_input>`;
   const full = renderTemplate(cfg.promptTemplate, { text, target_language: target });
   const system = sanitizeSystem(full);
-    const chatBody = { model: cfg.model, stream:true, temperature: cfg.temperature ?? 0, messages:[ { role:'system', content: system }, { role:'user', content: userContent } ] };
+    const chatBody = { model: cfg.model, stream:true, temperature: cfg.temperature ?? 0, messages:[ { role:'system', content: system }, { role:'user', content: buildChatContent(userContent, images) } ] };
     // 复用 chat 流式函数（不触发回退逻辑）
-    yield* streamChatOpenAI({ ...cfg, apiKey }, { model: chatBody.model, temperature: chatBody.temperature, instructions: system, input:[ { role:'user', content:[{ type:'input_text', text: userContent }] } ] }, opts.signal);
+    yield* streamChatOpenAI({ ...cfg, apiKey }, { model: chatBody.model, temperature: chatBody.temperature, instructions: system, input:[ { role:'user', content: buildResponsesContent(userContent, images) } ] }, opts.signal);
     return;
   } else if (cfg.apiType === 'claude') {
   const full2 = renderTemplate(cfg.promptTemplate, { text, target_language: target });
@@ -143,7 +211,7 @@ export async function * translateStream(text, opts={}){
       temperature: cfg.temperature ?? 0,
       system,
       stream: true,
-      messages: [ { role:'user', content:[{ type:'text', text: user }] } ]
+      messages: [ { role:'user', content: buildClaudeContent(user, images) } ]
     };
   yield* streamClaude({ ...cfg, apiKey }, payload, opts.signal);
     return;
@@ -193,9 +261,9 @@ async function * streamChatOpenAI(cfg, payload, externalSignal){
   const controller = new AbortController();
   if (externalSignal) externalSignal.addEventListener('abort', ()=>controller.abort(), { once:true });
   const timeout = setTimeout(()=>controller.abort(), cfg.timeoutMs||30000);
-  const userItem = payload?.input?.[0]?.content?.[0]?.text || '';
+  const userContent = responsesContentToChat(payload?.input?.[0]?.content || []);
   const system = sanitizeSystem(payload.instructions||'');
-  const chatBody = { model: payload.model, stream:true, temperature: payload.temperature, messages:[ system?{ role:'system', content: system }:null, { role:'user', content: userItem } ].filter(Boolean) };
+  const chatBody = { model: payload.model, stream:true, temperature: payload.temperature, messages:[ system?{ role:'system', content: system }:null, { role:'user', content: userContent.length ? userContent : '' } ].filter(Boolean) };
   let resp;
   try {
     resp = await fetch(cfg.baseUrl.replace(/\/$/,'') + '/chat/completions', { method:'POST', headers:{ 'Authorization':'Bearer '+(cfg.apiKey || cfg.apiKeyEnc), 'Content-Type':'application/json' }, body: JSON.stringify(chatBody), signal: controller.signal });

--- a/js/api.js
+++ b/js/api.js
@@ -45,7 +45,7 @@ function buildResponsesContent(userText, images){
   const content = [];
   if (userText || !images.length) content.push({ type:'input_text', text: userText });
   for (const img of normalizeImages(images)){
-    content.push({ type:'input_image', image_url: { url: img.dataUrl } });
+    content.push({ type:'input_image', image_url: img.dataUrl });
   }
   return content;
 }
@@ -73,8 +73,9 @@ function responsesContentToChat(content){
   const out = [];
   for (const item of content||[]){
     if (item?.type === 'input_text') out.push({ type:'text', text: item.text || '' });
-    else if (item?.type === 'input_image' && item.image_url?.url){
-      out.push({ type:'image_url', image_url:{ url: item.image_url.url } });
+    else if (item?.type === 'input_image' && (item.image_url || item.image_url?.url)){
+      const url = typeof item.image_url === 'string' ? item.image_url : item.image_url.url;
+      out.push({ type:'image_url', image_url:{ url } });
     }
   }
   return out;

--- a/js/config.js
+++ b/js/config.js
@@ -49,6 +49,7 @@ const defaultConfig = {
       baseUrl: 'https://api.openai.com/v1',
       apiKeyEnc: '',
       model: 'gpt-4o-mini',
+      vision: true,
       // 将温度与最大 Token 改为服务级别配置（兼容：若不存在则回退到全局默认值）
       temperature: 0,
       maxTokens: undefined
@@ -121,6 +122,8 @@ function normalizeServices(arr){
     if (!out.baseUrl) out.baseUrl = 'https://api.openai.com/v1';
     if (out.apiKeyEnc == null) out.apiKeyEnc = '';
     if (!out.model) out.model = 'gpt-4o-mini';
+    if (out.vision === undefined) out.vision = true;
+    else out.vision = !!out.vision;
     // 服务级别温度/最大 Token 的缺省与数值规范化
     if (out.temperature === undefined || out.temperature === '') out.temperature = 0;
     else out.temperature = Number(out.temperature);
@@ -151,6 +154,7 @@ function migrateToMultiServices(dataIn){
     baseUrl: data.baseUrl || 'https://api.openai.com/v1',
     apiKeyEnc: data.apiKeyEnc || '',
     model: data.model || 'gpt-4o-mini',
+    vision: data.vision === undefined ? true : !!data.vision,
     // 将旧的全局 temperature / maxTokens 迁移到首个服务
     temperature: (data.temperature!==undefined && data.temperature!=='') ? Number(data.temperature) : 0,
     maxTokens: (data.maxTokens!==undefined && data.maxTokens!=='') ? Number(data.maxTokens) : undefined

--- a/js/ui-settings-modal.js
+++ b/js/ui-settings-modal.js
@@ -116,7 +116,7 @@ function loadIntoForm(){
   [...form.querySelectorAll('[data-field]')].forEach(el=>{
     const key = el.getAttribute('data-field');
     if (['apiKey','masterPassword','promptTemplate'].includes(key)) return; // 这些字段单独处理
-    const serviceKeys = ['apiType','baseUrl','model','temperature','maxTokens'];
+    const serviceKeys = ['apiType','baseUrl','model','vision','temperature','maxTokens'];
     if (serviceKeys.includes(key)){
       if (el.type==='checkbox') el.checked = !!svc[key]; else el.value = svc[key] == null ? '' : svc[key];
     } else {
@@ -176,7 +176,7 @@ form.addEventListener('submit', async e=>{
     const key = el.getAttribute('data-field');
     if (key === 'apiKey' || key === 'masterPassword' || key === 'promptTemplate') return; // 跳过保存明文字段
     const val = el.type==='checkbox' ? el.checked : el.value.trim();
-    if (['apiType','baseUrl','model','temperature','maxTokens'].includes(key)) svc[key] = val;
+    if (['apiType','baseUrl','model','vision','temperature','maxTokens'].includes(key)) svc[key] = val;
     else next[key] = val;
   });
   const prompt = { ...getActivePrompt(cfg) };
@@ -524,7 +524,7 @@ btnAddSvc?.addEventListener('click', ()=>{
   const cfg = loadConfig();
   const idx = (cfg.services||[]).length + 1;
   const id = `svc-${Date.now()}-${idx}`;
-  const base = { id, name:`服务${idx}`, apiType:'openai-responses', baseUrl:'https://api.openai.com/v1', apiKeyEnc:'', model:'gpt-4o-mini', temperature: 0, maxTokens: undefined };
+  const base = { id, name:`服务${idx}`, apiType:'openai-responses', baseUrl:'https://api.openai.com/v1', apiKeyEnc:'', model:'gpt-4o-mini', vision: true, temperature: 0, maxTokens: undefined };
   cfg.services = [...(cfg.services||[]), base];
   cfg.activeServiceId = id;
   saveConfig(cfg); loadIntoForm(); statusEl.textContent = '已新增服务配置';

--- a/js/ui-translate.js
+++ b/js/ui-translate.js
@@ -477,6 +477,7 @@ inputEl.addEventListener('drop', async e=>{
 inputEl.addEventListener('paste', e=>{
   const files = parseDataTransferImages(e.clipboardData?.files||[]);
   if (files.length){
+    e.preventDefault();
     addImagesFromFiles(files, '粘贴');
   }
 });

--- a/js/ui-translate.js
+++ b/js/ui-translate.js
@@ -463,6 +463,11 @@ inputEl.addEventListener('drop', async e=>{
   const dt = e.dataTransfer;
   const files = Array.from(dt.files||[]);
   const nonImageFiles = files.filter(f=>!(f.type && f.type.startsWith('image/')));
+  if (files.length && files.length !== nonImageFiles.length){
+    e.stopImmediatePropagation();
+    await addImagesFromFiles(files, '拖拽');
+    return;
+  }
   await addImagesFromFiles(files, '拖拽');
   if (nonImageFiles.length){
     const f = nonImageFiles[0];
@@ -527,9 +532,10 @@ inputEl.addEventListener('paste', e=>{
   const dataUrlImages = extractDataUrlImagesFromHtml(html);
   if (files.length || dataUrlImages.length){
     e.preventDefault();
-    e.stopPropagation();
+    e.stopImmediatePropagation();
     if (files.length){ addImagesFromFiles(files, '粘贴'); }
     else { addImagesFromDataUrls(dataUrlImages, '粘贴'); }
+    return;
   }
 });
 


### PR DESCRIPTION
## Summary
- add a per-service vision toggle in the settings modal and default configs
- introduce image attachment controls on the translate page for clipboard, drag-drop, and file picker uploads when vision is enabled
- update translation requests to forward uploaded images to OpenAI/Claude payloads

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693691ed786c832c81437fdf4defff93)