### PR TITLE
Add image compression presets for uploads

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -57,6 +57,8 @@ textarea:focus{outline:2px solid var(--accent);outline-offset:0}
 fieldset{border:1px solid var(--border);border-radius:var(--radius);padding:10px;margin-bottom:var(--gap);display:flex;flex-direction:column;gap:8px}
 legend{padding:0 6px;font-size:12px;color:var(--fg-dim)}
 label{display:flex;flex-direction:column;font-size:12px;gap:4px}
+.inline-field{flex-direction:row;align-items:center;gap:6px;font-size:12px}
+label.inline-field select{min-width:120px}
 input,select{background:var(--input-bg);color:var(--fg);border:1px solid var(--border);border-radius:var(--radius);padding:6px;font:13px var(--font)}
 input:focus,select:focus{outline:2px solid var(--accent);outline-offset:0}
 .settings-body{display:flex;gap:16px}

--- a/index.html
+++ b/index.html
@@ -34,6 +34,14 @@
       <div class="attachment-bar" aria-label="图片输入">
         <div class="btn-row" style="align-items:center">
           <button id="btnAddImage" class="btn" type="button">添加图片</button>
+          <label class="inline-field" for="imageQualitySelect">压缩等级
+            <select id="imageQualitySelect">
+              <option value="none">不压缩</option>
+              <option value="balanced" selected>标准</option>
+              <option value="strong">强力</option>
+              <option value="extreme">超强</option>
+            </select>
+          </label>
           <span id="visionHint" class="status" aria-live="polite"></span>
         </div>
         <input type="file" id="imagePicker" accept="image/*" multiple hidden />


### PR DESCRIPTION
## Summary
- add a compression level selector next to image uploads
- compress images with selected preset before generating base64 payloads and enforce size limits after compression
- tweak attachment bar styling for inline compression selector

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69379c7ea074832cb1cb7ed0a6479f5e)